### PR TITLE
remove __DEV__=true flag from build:watch script

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "homepage": "https://github.com/ttebify/content-caddy#readme",
   "scripts": {
     "build": "tsc --noEmit && vite build",
-    "build:watch": "__DEV__=true vite build --watch",
+    "build:watch": "vite build --watch",
     "build:hmr": "rollup --config utils/reload/rollup.config.ts",
     "wss": "node utils/reload/initReloadServer.js",
     "dev": "npm run build:hmr && (run-p wss build:watch)",


### PR DESCRIPTION
Hello @ttebify ! I just cloned the content-caddy repo from you. ``` __DEV__=true``` flag from ```build:watch``` script causes an error when running ```yarn dev``` script. Without it, the command works just fine.  Any specific reason why it's here?